### PR TITLE
PyCharm and other IntelliJ Platform IDEs

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -27,4 +27,5 @@
         Luke Amdor
     </vendor>
     <idea-version since-build="8000"/>
+    <depends>com.intellij.modules.platform</depends>
 </idea-plugin>

--- a/src/test/java/intellij/mark/MarkTestCase.java
+++ b/src/test/java/intellij/mark/MarkTestCase.java
@@ -9,7 +9,7 @@ import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.EditorFactory;
 import com.intellij.openapi.ide.CopyPasteManager;
-import com.intellij.testFramework.LightIdeaTestCase;
+import com.intellij.testFramework.LightPlatformTestCase;
 
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.StringSelection;
@@ -19,7 +19,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-public abstract class MarkTestCase extends LightIdeaTestCase {
+public abstract class MarkTestCase extends LightPlatformTestCase {
     private EditorFactory editorFactory;
     private List<Editor> openEditors;
     private Editor currentEditor;


### PR DESCRIPTION
Hi!

Let me just say that I really love your plugin. Recently I noticed it's not available for PyCharm, because plugin.xml lacks one line (and therefore the plugin is considered a "legacy plugin"). This patch fixes it (I had to change one more thing to make it compile agains recent IDEA).

You might also consider dropping "IDEA" from the name now :)

Cheers,

Michał Bendowski
